### PR TITLE
Add release plugin related information

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id "base"
     id "com.github.spotbugs" version "4.0.5"
     id "de.undercouch.download" version "4.0.4"
+    id 'net.researchgate.release' version '2.6.0'
 }
 
 description = 'Ballerinax - DataMapper Extension'
@@ -33,6 +34,38 @@ allprojects {
 
 subprojects {
     apply plugin: 'java'
+    apply plugin: 'maven-publish'
+    publishing {
+        repositories {
+            maven {
+                if (project.version.endsWith('-SNAPSHOT')) {
+                    url "https://maven.wso2.org/nexus/content/repositories/snapshots/"
+                } else {
+                    url "https://maven.wso2.org/nexus/service/local/staging/deploy/maven2/"
+                }
+                credentials {
+                    username System.getenv("NEXUS_USERNAME")
+                    password System.getenv("NEXUS_PASSWORD")
+                }
+            }
+        }
+    }
+
+    release {
+        // Disable check snapshots temporarily
+        buildTasks = []
+        failOnSnapshotDependencies = false
+        failOnCommitNeeded = false
+        versionPropertyFile = 'gradle.properties'
+        tagTemplate = 'v${version}'
+        git {
+            // To release from any branch
+            requireBranch = null
+        }
+    }
+
+    afterReleaseBuild.dependsOn publishToMavenLocal
+    afterReleaseBuild.dependsOn publish
 }
 
 apply from: "gradle/javaProject.gradle"

--- a/gradle/javaProject.gradle
+++ b/gradle/javaProject.gradle
@@ -1,6 +1,7 @@
 apply plugin: "java"
 apply plugin: "com.github.spotbugs"
 apply plugin: "checkstyle"
+apply plugin: 'maven-publish'
 
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
@@ -100,6 +101,17 @@ checkstyle {
     toolVersion '7.8.2'
     configFile rootProject.file("build-config/checkstyle/build/checkstyle.xml")
     configProperties = ["suppressionFile" : rootProject.file("build-config/checkstyle/build/suppressions.xml")]
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            groupId project.group
+            artifactId project.name
+            version = project.version
+            from components.java
+        }
+    }
 }
 
 spotbugsMain.finalizedBy validateSpotbugs

--- a/settings.gradle
+++ b/settings.gradle
@@ -19,7 +19,7 @@ plugins {
     id "com.gradle.enterprise" version "3.2"
 }
 
-rootProject.name = 'datamapper-extension-parent'
+rootProject.name = 'datamapper-extension'
 include(':build-config:checkstyle')
 
 gradleEnterprise {


### PR DESCRIPTION
## Purpose
Add the release plugin related information

## Goals
Add the release plugin related information so that the compiler extension JAR can be published to the NEXUS.

## Approach
N/A

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
N/A

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
JDK 1.8
 
## Learning
N/A