### PR TITLE
Fix a bug which leads to bad sad error

### DIFF
--- a/src/main/java/org/ballerinax/datamapper/DataMapperPlugin.java
+++ b/src/main/java/org/ballerinax/datamapper/DataMapperPlugin.java
@@ -366,6 +366,7 @@ public class DataMapperPlugin extends AbstractCompilerPlugin {
                         }
 
                         typeRecord = constructJSON(value);
+                        currentTypeStructure = typeRecord.toString();
                         Iterator<String> iterator = typeRecord.get(name).fieldNames();
                         expectedNumberOfAttributes = 0;
                         while (iterator.hasNext()) {


### PR DESCRIPTION
## Purpose
To fix a bug which throws a bad sad error. The compiler extension executes happy path (i.e., without any errors) as long as the user does not submit a data file which includes nested sample data. In such case, during the repeated rounds of compilation, only the first round executes without any error. The rest of the attempts end up throwing bad sad error due to a NullPointerException getting thrown from the compiler extension. 

## Goals
To fix the above mentioned bug.

## Approach
N/A

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report?no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
JDK 1.8
 
## Learning
N/A