### PR TITLE
Fix a bug related to handling record types

### DIFF
--- a/src/main/java/org/ballerinax/datamapper/DataMapperStructureVisitor.java
+++ b/src/main/java/org/ballerinax/datamapper/DataMapperStructureVisitor.java
@@ -46,6 +46,10 @@ public class DataMapperStructureVisitor extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangTypeDefinition typeDefinition) {
+        if (!(typeDefinition.typeNode instanceof BLangRecordTypeNode)) {
+            return;
+        }
+
         for (BLangSimpleVariable field: ((BLangRecordTypeNode) typeDefinition.typeNode).fields) {
             if (field.getKind() == NodeKind.VARIABLE) {
                 field.accept(this);


### PR DESCRIPTION
## Purpose
Fix a bug related to handling record types.

## Goals
Fix a bug related to handling record types.

## Approach
The cause for the bug was the assumption that every `typeDefinition.typeNode` can be a BLangRecordTypeNode. However, it can be one of these [types](https://ballerina.io/ballerina-spec/spec.html#type-descriptor).

```
        for (BLangSimpleVariable field: ((BLangRecordTypeNode) typeDefinition.typeNode).fields) {
            if (field.getKind() == NodeKind.VARIABLE) {
                field.accept(this);
            }
        }
```
Hence we have to type cast only after checking the type of the object. This can be done by checking the tag as well as using `instanceof` keyword. In this PR we are using the latter approach.

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
JDK 1.8, Ubuntu 18.04
 
## Learning
N/A