### PR TITLE
Fix a bug related to importing external connector modules

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 org.gradle.caching=true
 org.gradle.jvmargs='-Dfile.encoding=UTF-8'
 group=org.ballerinax.datamapper
-version=2.0.0-SNAPSHOT
+version=2.0.0-Preview2-SNAPSHOT
 systemProp.org.gradle.internal.publish.checksums.insecure=true

--- a/src/main/java/org/ballerinax/datamapper/DataMapperPlugin.java
+++ b/src/main/java/org/ballerinax/datamapper/DataMapperPlugin.java
@@ -33,6 +33,7 @@ import org.ballerinalang.model.symbols.SymbolKind;
 import org.ballerinalang.model.tree.NodeKind;
 import org.ballerinalang.model.tree.PackageNode;
 import org.ballerinalang.model.tree.TopLevelNode;
+import org.ballerinalang.project.Project;
 import org.ballerinalang.util.diagnostic.Diagnostic;
 import org.ballerinalang.util.diagnostic.DiagnosticLog;
 import org.ballerinax.datamapper.util.Utils;
@@ -45,6 +46,7 @@ import org.wso2.ballerinalang.compiler.tree.BLangTypeDefinition;
 import org.wso2.ballerinalang.compiler.tree.types.BLangObjectTypeNode;
 import org.wso2.ballerinalang.compiler.tree.types.BLangType;
 import org.wso2.ballerinalang.compiler.tree.types.BLangUnionTypeNode;
+import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.diagnotic.BDiagnosticSource;
 import org.wso2.ballerinalang.compiler.util.diagnotic.DiagnosticPos;
 import org.wso2.ballerinalang.util.Flags;
@@ -85,6 +87,12 @@ public class DataMapperPlugin extends AbstractCompilerPlugin {
     private boolean noFunctionsFlag;
     private JsonParser parser;
     private String currentTypeStructure;
+    private CompilerContext context = null;
+
+    @Override
+    public void setCompilerContext(CompilerContext ctx) {
+        context = ctx;
+    }
 
     @Override
     public void init(DiagnosticLog diagnosticLog) {
@@ -97,6 +105,12 @@ public class DataMapperPlugin extends AbstractCompilerPlugin {
 
     @Override
     public void process(PackageNode packageNode) {
+        Project project = context.get(Project.PROJECT_KEY);
+
+        if (!project.isModuleExists(((BLangPackage) packageNode).packageID)) {
+            return;
+        }
+
         for (TopLevelNode node : ((BLangPackage) packageNode).topLevelNodes) {
             if (node instanceof BLangTypeDefinition) {
                 if ((((BLangTypeDefinition) node).getTypeNode().type.flags & Flags.CLIENT) == Flags.CLIENT) {


### PR DESCRIPTION
## Purpose
A bad sad error was thrown when building a project which imported an external connector module into a Ballerina app using Ballerina Swan Lake Preview 1. Specifically, this error is thrown when the build process was invoked for the second round. This is because when the compilation was done for the first time, the data mapper compiler extension generates functions JSON file and when the compilation is run again it fails to invoke the data mapper compiler extension because the functions JSON file already exists.

## Goals
Fix bug which is caused when importing external connector modules.

## Approach
Add a code snippet to check whether the processing happens within the same source project or not.

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Performance tests
A performance test was carried out on a computer having 4 CPU cores, and 16GB RAM with more than 100GB free disk space. The computer was installed Ubuntu 18.04, JDK 1.8. Tests were carried out using three Ballerina connectors and two Ballerina by example sample applications.

| Connector/Application  |  Latency with Data Mapper Plugin (s) | Latency without Data Mapaper Plugin (s)  | Increase in Latency (s)  | Percentage Increase in build time (%)  |
|---|---|---|---|---|
| Slack | 3.49 | 3.33 | 0.16 | 4.95|
|Github | 3.83 | 3.70 | 0.13 | 3.51|
|Sfdc | 4.03 | 3.87 | 0.16 | 4.03|
|Workers example from BBE | 2.48 | 2.55 | 0.04 | 1.58|
|JSON arrays example from BBE | 2.463413834 | 2.456724361 | 0.0066 | 0.27|



## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
[Need a flag to indicate a packageNode is from the source project](https://github.com/ballerina-platform/ballerina-lang/issues/24441)

## Migrations (if applicable)
N/A

## Test environment
JDK 1.8, Ubuntu 18.04, Ballerina Swan Lake Preview 1
 
## Learning
N/A