### PR TITLE
Migrate the Data Mapper Compiler Plugin to JDK 11

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
+      - name: Set up JDK 1.11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 1.11
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Gradle

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
+      - name: Set up JDK 1.11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 1.11
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Gradle

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
+      - name: Set up JDK 1.11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 1.11
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Gradle

--- a/build.gradle
+++ b/build.gradle
@@ -38,9 +38,12 @@ allprojects {
             }
         }
         
-        /* Ballerina lang staging repository */
         maven {
-            url = 'https://maven.wso2.org/nexus/content/repositories/orgballerinalang-1590/'
+            url = 'https://maven.pkg.github.com/ballerina-platform/ballerina-lang'
+            credentials {
+                username System.getenv("packageUser")
+                password System.getenv("packagePAT")
+            }
         }
     }
 }

--- a/gradle/javaProject.gradle
+++ b/gradle/javaProject.gradle
@@ -7,7 +7,7 @@ tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
+sourceCompatibility = JavaVersion.VERSION_11
 
 configurations {
     bDistributionDir

--- a/src/main/java/org/ballerinax/datamapper/DataMapperPlugin.java
+++ b/src/main/java/org/ballerinax/datamapper/DataMapperPlugin.java
@@ -249,8 +249,9 @@ public class DataMapperPlugin extends AbstractCompilerPlugin {
         Path issueDataFilePath = Paths.get(projectSourceFolder, "src", moduleName, "resources");
         List<String> listOfSampleDataJSONFiles = null;
 
-        try (Stream<Path> walk = Files.walk(issueDataFilePath)) {
-            listOfSampleDataJSONFiles = walk.map(x -> x.toString())
+        try {
+            Stream<Path> files = Files.walk(issueDataFilePath);
+            listOfSampleDataJSONFiles = files.map(x -> x.toString())
                     .filter(f -> f.endsWith("_data.json")).collect(Collectors.toList());
 
             for (String path : listOfSampleDataJSONFiles) {


### PR DESCRIPTION
## Purpose
Migrate the Data Mapper Compiler Plugin to JDK 11.

## Goals
Migrate the Data Mapper Compiler Plugin to JDK 11.

## Approach
N/A

## User stories
N/A

## Release note
Migrate the Data Mapper Compiler Plugin to JDK 11.

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
JDK 11.0.8, Ubuntu 18.04
 
## Learning
N/A