### PR TITLE
Fix the issue of remote method calls having a visibility qualifier

### DIFF
--- a/src/test/java/org/ballerinax/datamapper/DataMapperPluginTest.java
+++ b/src/test/java/org/ballerinax/datamapper/DataMapperPluginTest.java
@@ -293,7 +293,15 @@ public class DataMapperPluginTest {
             Files.deleteIfExists(Paths.get(path + "cache/ballerinax/test1/0.1.0"));
             Files.deleteIfExists(Paths.get(path + "cache/ballerinax/test1"));
             Files.deleteIfExists(Paths.get(path + "cache/ballerinax"));
+            Files.deleteIfExists(Paths.get(path + "cache/tests_cache"));
             Files.deleteIfExists(Paths.get(path + "cache"));
+
+            Files.deleteIfExists(Paths.get(path + "balo/ballerinax-test1-any-0.1.0.balo"));
+            Files.deleteIfExists(Paths.get(path + "balo"));
+
+            Files.deleteIfExists(Paths.get(path + "bin/test1.jar"));
+            Files.deleteIfExists(Paths.get(path + "bin"));
+
             Files.deleteIfExists(Paths.get(path));
 
             path = "src/test/resources/test2/modules/module_test2/resources/";
@@ -388,7 +396,15 @@ public class DataMapperPluginTest {
             Files.deleteIfExists(Paths.get(path + "cache/ballerinax/test5/0.1.0"));
             Files.deleteIfExists(Paths.get(path + "cache/ballerinax/test5"));
             Files.deleteIfExists(Paths.get(path + "cache/ballerinax"));
+            Files.deleteIfExists(Paths.get(path + "cache/tests_cache"));
             Files.deleteIfExists(Paths.get(path + "cache"));
+
+            Files.deleteIfExists(Paths.get(path + "balo/ballerinax-test5-any-0.1.0.balo"));
+            Files.deleteIfExists(Paths.get(path + "balo"));
+
+            Files.deleteIfExists(Paths.get(path + "bin/test5.jar"));
+            Files.deleteIfExists(Paths.get(path + "bin"));
+
             Files.deleteIfExists(Paths.get(path));
 
             path = "src/test/resources/test6/modules/module_test6/resources/";
@@ -434,7 +450,15 @@ public class DataMapperPluginTest {
             Files.deleteIfExists(Paths.get(path + "cache/ballerinax/test7/0.1.0"));
             Files.deleteIfExists(Paths.get(path + "cache/ballerinax/test7"));
             Files.deleteIfExists(Paths.get(path + "cache/ballerinax"));
+            Files.deleteIfExists(Paths.get(path + "cache/tests_cache"));
             Files.deleteIfExists(Paths.get(path + "cache"));
+
+            Files.deleteIfExists(Paths.get(path + "balo/ballerinax-test7-any-0.1.0.balo"));
+            Files.deleteIfExists(Paths.get(path + "balo"));
+
+            Files.deleteIfExists(Paths.get(path + "bin/test7.jar"));
+            Files.deleteIfExists(Paths.get(path + "bin"));
+
             Files.deleteIfExists(Paths.get(path));
 
             path = "src/test/resources/test8/target/";
@@ -447,7 +471,15 @@ public class DataMapperPluginTest {
             Files.deleteIfExists(Paths.get(path + "cache/ballerinax/test8/0.1.0"));
             Files.deleteIfExists(Paths.get(path + "cache/ballerinax/test8"));
             Files.deleteIfExists(Paths.get(path + "cache/ballerinax"));
+            Files.deleteIfExists(Paths.get(path + "cache/tests_cache"));
             Files.deleteIfExists(Paths.get(path + "cache"));
+
+            Files.deleteIfExists(Paths.get(path + "balo/ballerinax-test8-any-0.1.0.balo"));
+            Files.deleteIfExists(Paths.get(path + "balo"));
+
+            Files.deleteIfExists(Paths.get(path + "bin/test8.jar"));
+            Files.deleteIfExists(Paths.get(path + "bin"));
+
             Files.deleteIfExists(Paths.get(path));
 
             path = "src/test/resources/test9/modules/module_test9/resources/";
@@ -470,7 +502,15 @@ public class DataMapperPluginTest {
             Files.deleteIfExists(Paths.get(path + "cache/ballerinax/test9/0.1.0"));
             Files.deleteIfExists(Paths.get(path + "cache/ballerinax/test9"));
             Files.deleteIfExists(Paths.get(path + "cache/ballerinax"));
+            Files.deleteIfExists(Paths.get(path + "cache/tests_cache"));
             Files.deleteIfExists(Paths.get(path + "cache"));
+
+            Files.deleteIfExists(Paths.get(path + "balo/ballerinax-test9-any-0.1.0.balo"));
+            Files.deleteIfExists(Paths.get(path + "balo"));
+
+            Files.deleteIfExists(Paths.get(path + "bin/test9.jar"));
+            Files.deleteIfExists(Paths.get(path + "bin"));
+
             Files.deleteIfExists(Paths.get(path));
 
             path = "src/test/resources/test10/modules/module_test10/resources/";
@@ -494,7 +534,15 @@ public class DataMapperPluginTest {
             Files.deleteIfExists(Paths.get(path + "cache/ballerinax/test10/0.1.0"));
             Files.deleteIfExists(Paths.get(path + "cache/ballerinax/test10"));
             Files.deleteIfExists(Paths.get(path + "cache/ballerinax"));
+            Files.deleteIfExists(Paths.get(path + "cache/tests_cache"));
             Files.deleteIfExists(Paths.get(path + "cache"));
+
+            Files.deleteIfExists(Paths.get(path + "balo/ballerinax-test10-any-0.1.0.balo"));
+            Files.deleteIfExists(Paths.get(path + "balo"));
+
+            Files.deleteIfExists(Paths.get(path + "bin/test10.jar"));
+            Files.deleteIfExists(Paths.get(path + "bin"));
+
             Files.deleteIfExists(Paths.get(path));
 
             path = "src/test/resources/test11/modules/module_test11/resources/";
@@ -517,7 +565,14 @@ public class DataMapperPluginTest {
             Files.deleteIfExists(Paths.get(path + "cache/ballerinax/test11/0.1.0"));
             Files.deleteIfExists(Paths.get(path + "cache/ballerinax/test11"));
             Files.deleteIfExists(Paths.get(path + "cache/ballerinax"));
+            Files.deleteIfExists(Paths.get(path + "cache/tests_cache"));
             Files.deleteIfExists(Paths.get(path + "cache"));
+
+            Files.deleteIfExists(Paths.get(path + "balo/ballerinax-test11-any-0.1.0.balo"));
+            Files.deleteIfExists(Paths.get(path + "balo"));
+
+            Files.deleteIfExists(Paths.get(path + "bin/test11.jar"));
+            Files.deleteIfExists(Paths.get(path + "bin"));
             Files.deleteIfExists(Paths.get(path));
 
             Files.deleteIfExists(Paths.get("src/test/resources/test12/modules/module_test12/resources/" +
@@ -535,7 +590,14 @@ public class DataMapperPluginTest {
             Files.deleteIfExists(Paths.get(path + "cache/ballerinax/test12/0.1.0"));
             Files.deleteIfExists(Paths.get(path + "cache/ballerinax/test12"));
             Files.deleteIfExists(Paths.get(path + "cache/ballerinax"));
+            Files.deleteIfExists(Paths.get(path + "cache/tests_cache"));
             Files.deleteIfExists(Paths.get(path + "cache"));
+
+            Files.deleteIfExists(Paths.get(path + "balo/ballerinax-test12-any-0.1.0.balo"));
+            Files.deleteIfExists(Paths.get(path + "balo"));
+
+            Files.deleteIfExists(Paths.get(path + "bin/test12.jar"));
+            Files.deleteIfExists(Paths.get(path + "bin"));
             Files.deleteIfExists(Paths.get(path));
 
             Files.deleteIfExists(Paths.get("src/test/resources/test13/modules/module_test13/resources/" +
@@ -553,7 +615,14 @@ public class DataMapperPluginTest {
             Files.deleteIfExists(Paths.get(path + "cache/ballerinax/test13/0.1.0"));
             Files.deleteIfExists(Paths.get(path + "cache/ballerinax/test13"));
             Files.deleteIfExists(Paths.get(path + "cache/ballerinax"));
+            Files.deleteIfExists(Paths.get(path + "cache/tests_cache"));
             Files.deleteIfExists(Paths.get(path + "cache"));
+
+            Files.deleteIfExists(Paths.get(path + "balo/ballerinax-test13-any-0.1.0.balo"));
+            Files.deleteIfExists(Paths.get(path + "balo"));
+
+            Files.deleteIfExists(Paths.get(path + "bin/test13.jar"));
+            Files.deleteIfExists(Paths.get(path + "bin"));
             Files.deleteIfExists(Paths.get(path));
 
             path = "src/test/resources/test14/modules/module_test14/resources/";
@@ -577,7 +646,14 @@ public class DataMapperPluginTest {
             Files.deleteIfExists(Paths.get(path + "cache/ballerinax/test14/0.1.0"));
             Files.deleteIfExists(Paths.get(path + "cache/ballerinax/test14"));
             Files.deleteIfExists(Paths.get(path + "cache/ballerinax"));
+            Files.deleteIfExists(Paths.get(path + "cache/tests_cache"));
             Files.deleteIfExists(Paths.get(path + "cache"));
+
+            Files.deleteIfExists(Paths.get(path + "balo/ballerinax-test14-any-0.1.0.balo"));
+            Files.deleteIfExists(Paths.get(path + "balo"));
+
+            Files.deleteIfExists(Paths.get(path + "bin/test14.jar"));
+            Files.deleteIfExists(Paths.get(path + "bin"));
             Files.deleteIfExists(Paths.get(path));
 
             path = "src/test/resources/test15/modules/module_test15/resources/";
@@ -597,7 +673,14 @@ public class DataMapperPluginTest {
             Files.deleteIfExists(Paths.get(path + "cache/ballerinax/test15/0.1.0"));
             Files.deleteIfExists(Paths.get(path + "cache/ballerinax/test15"));
             Files.deleteIfExists(Paths.get(path + "cache/ballerinax"));
+            Files.deleteIfExists(Paths.get(path + "cache/tests_cache"));
             Files.deleteIfExists(Paths.get(path + "cache"));
+
+            Files.deleteIfExists(Paths.get(path + "balo/ballerinax-test15-any-0.1.0.balo"));
+            Files.deleteIfExists(Paths.get(path + "balo"));
+
+            Files.deleteIfExists(Paths.get(path + "bin/test15.jar"));
+            Files.deleteIfExists(Paths.get(path + "bin"));
             Files.deleteIfExists(Paths.get(path));
 
         } catch (IOException e) {

--- a/src/test/resources/test1/modules/module_test1/connector_endpoint.bal
+++ b/src/test/resources/test1/modules/module_test1/connector_endpoint.bal
@@ -15,7 +15,7 @@
 // under the License.
 
 public client class Client {
-    public remote function createIssue()  returns Issue|error {
+    remote function createIssue()  returns Issue|error {
         return {};
     }
 }

--- a/src/test/resources/test10/modules/module_test10/connector_endpoint.bal
+++ b/src/test/resources/test10/modules/module_test10/connector_endpoint.bal
@@ -15,7 +15,7 @@
 // under the License.
 
 public client class Client {
-    public remote function createIssue()  returns Issue|error {
+    remote function createIssue()  returns Issue|error {
         return {};
     }
 }

--- a/src/test/resources/test11/modules/module_test11/connector_endpoint.bal
+++ b/src/test/resources/test11/modules/module_test11/connector_endpoint.bal
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 public client class Client {
-    public remote function createIssue()  returns Issue|error {
+    remote function createIssue()  returns Issue|error {
         return {};
     }
 }

--- a/src/test/resources/test12/modules/module_test12/connector_endpoint.bal
+++ b/src/test/resources/test12/modules/module_test12/connector_endpoint.bal
@@ -15,7 +15,7 @@
 // under the License.
 
 public client class Client {
-    public remote function createIssue()  returns string {
+    remote function createIssue()  returns string {
         return "";
     }
 }

--- a/src/test/resources/test13/modules/module_test13/connector_endpoint.bal
+++ b/src/test/resources/test13/modules/module_test13/connector_endpoint.bal
@@ -15,7 +15,7 @@
 // under the License.
 
 public client class Client {
-    public remote function createIssue()  returns string {
+    remote function createIssue()  returns string {
         return "";
     }
 }

--- a/src/test/resources/test14/modules/module_test14/connector_endpoint.bal
+++ b/src/test/resources/test14/modules/module_test14/connector_endpoint.bal
@@ -15,13 +15,13 @@
 // under the License.
 
 public client class Client1 {
-    public remote function createIssue()  returns Issue|error {
+    remote function createIssue()  returns Issue|error {
         return {};
     }
 }
 
 public client class Client2 {
-    public remote function getIssue()  returns Issue|error {
+    remote function getIssue()  returns Issue|error {
         return {};
     }
 }

--- a/src/test/resources/test15/modules/module_test15/connector_endpoint.bal
+++ b/src/test/resources/test15/modules/module_test15/connector_endpoint.bal
@@ -21,7 +21,7 @@ public client class '\ \/\:\@\[\`\{\~_Connector {
 
     }
 
-    public remote function '\ \/\:\@\[\`\{\~_Action() returns string {
+    remote function '\ \/\:\@\[\`\{\~_Action() returns string {
         string 'sample_String_2 = "this ";
         return 'sample_String_2 ;
     }

--- a/src/test/resources/test2/modules/module_test2/connector_endpoint.bal
+++ b/src/test/resources/test2/modules/module_test2/connector_endpoint.bal
@@ -15,7 +15,7 @@
 // under the License.
 
 public client class Client {
-    public remote function createIssue()  returns Issue|error {
+    remote function createIssue()  returns Issue|error {
         return {};
     }
 }

--- a/src/test/resources/test3/modules/module_test3/connector_endpoint.bal
+++ b/src/test/resources/test3/modules/module_test3/connector_endpoint.bal
@@ -15,7 +15,7 @@
 // under the License.
 
 public client class Client {
-    public remote function createIssue()  returns Issue|error {
+    remote function createIssue()  returns Issue|error {
         return {};
     }
 }

--- a/src/test/resources/test4/modules/module_test4/connector_endpoint.bal
+++ b/src/test/resources/test4/modules/module_test4/connector_endpoint.bal
@@ -15,7 +15,7 @@
 // under the License.
 
 public client class Client {
-    public remote function createIssue()  returns Issue|error {
+    remote function createIssue()  returns Issue|error {
         return {};
     }
 }

--- a/src/test/resources/test5/modules/module_test5/connector_endpoint.bal
+++ b/src/test/resources/test5/modules/module_test5/connector_endpoint.bal
@@ -15,7 +15,7 @@
 // under the License.
 
 public client class Client {
-    public remote function createIssue()  returns Issue|error {
+    remote function createIssue()  returns Issue|error {
         return {};
     }
 }

--- a/src/test/resources/test6/modules/module_test6/connector_endpoint.bal
+++ b/src/test/resources/test6/modules/module_test6/connector_endpoint.bal
@@ -15,7 +15,7 @@
 // under the License.
 
 public client class Client {
-    public remote function createIssue()  returns Issue|error {
+    remote function createIssue()  returns Issue|error {
         return {};
     }
 }

--- a/src/test/resources/test7/modules/module_test7/connector_endpoint.bal
+++ b/src/test/resources/test7/modules/module_test7/connector_endpoint.bal
@@ -15,7 +15,7 @@
 // under the License.
 
 public client class Client {
-    public remote function createIssue()  returns Issue|error {
+    remote function createIssue()  returns Issue|error {
         return {};
     }
 }

--- a/src/test/resources/test9/modules/module_test9/connector_endpoint.bal
+++ b/src/test/resources/test9/modules/module_test9/connector_endpoint.bal
@@ -15,7 +15,7 @@
 // under the License.
 
 public client class Client {
-    public remote function createIssue()  returns Issue|error {
+    remote function createIssue()  returns Issue|error {
         return {};
     }
 }


### PR DESCRIPTION
## Purpose
Fix the test case build failure which happens due to test case Ballerina projects having remote method calls with visibility qualifiers. With Ballerina SLP7 release remote functions are public by definition and hence visibility qualifier are not allowed anymore for remote function calls.

## Goals
Fix the test cases failure.

## Approach
We remove the appearance of `public` keyword in all the remote function calls. Furthermore, there were few new files getting created inside the target folder of Ballerina projects. Hence we need to delete those as well to get the  tearDown() method of the test cases file to work properly.

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
JDK 11, Ubuntu 18.04, Ballerina SLP7-SNAPSHOT
 
## Learning
N/A