### PR TITLE
Change diagnostic property package import location

### DIFF
--- a/src/main/java/org/ballerinax/datamapper/diagnostic/DataMapperDiagnostic.java
+++ b/src/main/java/org/ballerinax/datamapper/diagnostic/DataMapperDiagnostic.java
@@ -19,8 +19,8 @@ package org.ballerinax.datamapper.diagnostic;
 
 import io.ballerina.tools.diagnostics.Diagnostic;
 import io.ballerina.tools.diagnostics.DiagnosticInfo;
+import io.ballerina.tools.diagnostics.DiagnosticProperty;
 import io.ballerina.tools.diagnostics.Location;
-import io.ballerina.tools.diagnostics.properties.DiagnosticProperty;
 
 import java.util.List;
 


### PR DESCRIPTION
## Purpose
Fix ballerina compiler build failure
Change diagnostic property package import location

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes